### PR TITLE
Exchange librosa.output.write with soundfile.write (Librosa deprecated)

### DIFF
--- a/vocoder.ipynb
+++ b/vocoder.ipynb
@@ -23,7 +23,7 @@
     "    c = spect[1]\n",
     "    print(name)\n",
     "    waveform = wavegen(model, c=c)   \n",
-    "    soundfile.write_wav(name+'.wav', waveform, samplerate=16000)"
+    "    sf.write(name+'.wav', waveform, samplerate=16000)"
    ]
   }
  ],


### PR DESCRIPTION
Librosa's output writing function is deprecated since 0.7.0 (see https://librosa.org/doc/0.7.2/generated/librosa.output.write_wav.html). They propose to use soundfile.write instead. 